### PR TITLE
Add support for Ki, Mi, Gi and Ti

### DIFF
--- a/README
+++ b/README
@@ -234,3 +234,6 @@ If you have GNU tail:
 or, if you have recent BSD tail:
     tail -F /var/log/syslog | grcat conf.log >/dev/tty12
 
+If you want to start using grc automatically with supported commands, add
+		source /etc/grc.bashrc
+to your .bash_profile (assuming you copied grc.bashrc to /etc)

--- a/conf.df
+++ b/conf.df
@@ -3,19 +3,19 @@ regexp=^.*?\s
 colours=green
 ======
 # Size 'K'
-regexp=\s\d*[.,]?\dK\s
+regexp=\s\d*[.,]?\dKi?\s
 colours=green
 ======
 # Size 'M'
-regexp=\s\d*[.,]?\dM\s
+regexp=\s\d*[.,]?\dMi?\s
 colours=yellow
 ======
 # Size 'G'
-regexp=\s\d*[.,]?\dG\s
+regexp=\s\d*[.,]?\dGi?\s
 colours=red
 ======
 # Size 'T'
-regexp=\s\d*[.,]?\dT\s
+regexp=\s\d*[.,]?\dTi?\s
 colours=bold red
 ======
 # Mounted on

--- a/grc.bashrc
+++ b/grc.bashrc
@@ -1,0 +1,23 @@
+GRC=`which grc`
+if [ "$TERM" != dumb ] && [ -n "$GRC" ]
+then
+    alias colourify="$GRC -es --colour=auto"
+    alias configure='colourify ./configure'
+    alias diff='colourify diff'
+    alias make='colourify make'
+    alias gcc='colourify gcc'
+    alias g++='colourify g++'
+    alias as='colourify as'
+    alias gas='colourify gas'
+    alias ld='colourify ld'
+    alias netstat='colourify netstat'
+    alias ping='colourify ping'
+    alias traceroute='colourify /usr/sbin/traceroute'
+    alias head='colourify head'
+    alias tail='colourify tail'
+    alias dig='colourify dig'
+    alias mount='colourify mount'
+    alias ps='colourify ps'
+    alias mtr='colourify mtr'
+    alias df='colourify df'
+fi


### PR DESCRIPTION
Add support for Ki, Mi, Gi and Ti (Mac OS X / Darwin uses these units instead of K, M, G and T)