### PR TITLE
Support ifconfig interface highlighting also on BSD systems 

### DIFF
--- a/conf.ifconfig
+++ b/conf.ifconfig
@@ -16,7 +16,7 @@ regexp=\d+(\.\d+)?\s(T|G|M|K|)i?B
 colours=yellow
 =======
 # interface
-regexp=^(([a-z]{3,}\d*)|lo)\s
+regexp=^([a-z0-9]{2,}\d*):?\s
 colours=bold green
 =======
 #ip disc


### PR DESCRIPTION
(verified to still work on Linux).

Added 0-9 for main interface name because of interfaces like p2p0. 

Example ifconfig output:

```
lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST> mtu 16384
	options=3<RXCSUM,TXCSUM>
	inet6 ::1 prefixlen 128
	inet 127.0.0.1 netmask 0xff000000
	inet6 fe80::1%lo0 prefixlen 64 scopeid 0x1
	nd6 options=1<PERFORMNUD>
gif0: flags=8010<POINTOPOINT,MULTICAST> mtu 1280
stf0: flags=0<> mtu 1280
p2p0: flags=8843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> mtu 2304
	ether 02:03:08:8c:ba:92
	media: autoselect
	status: inactive
```