### PR TITLE
conf.df: fix mounted on

### DIFF
--- a/conf.df
+++ b/conf.df
@@ -19,7 +19,7 @@ regexp=\s\d*[.,]?\dTi?\s
 colours=bold red
 ======
 # Mounted on
-regexp=/\w*
+regexp=/[-\w\d./]*
 colours=bold green
 ======
 # Use 0-60%


### PR DESCRIPTION
Fixes highlighting in cases like this:
```
overlaid         4052872    152284   3900588    4% /tmp/duncan-firefox-kmx5veqj.default
```