### PR TITLE
use env python

### DIFF
--- a/grc
+++ b/grc
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#! /usr/bin/env python
 
 import os, re, string, sys, getopt, signal
 

--- a/grcat
+++ b/grcat
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#! /usr/bin/env python
 
 import sys, os, string, re, signal, errno
 


### PR DESCRIPTION
If /usr/bin/python is too old, `grcat` occurs the error below.

```bash
$ grcat
  File "/usr/local/bin/grcat", line 252
    except IOError as e:
                    ^
SyntaxError: invalid syntax
```

This patch is to specify `/usr/bin/env python` in the shebang and use your newer python.