### PR TITLE
Move installation files to /../local/../

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,9 +3,9 @@
 set -e
 
 DESTDIR=$1
-BINDIR=$DESTDIR/usr/bin
-LIBDIR=$DESTDIR/usr/share/grc
-MANDIR=$DESTDIR/usr/share/man/man1
+BINDIR=$DESTDIR/usr/local/bin
+LIBDIR=$DESTDIR/usr/local/share/grc
+MANDIR=$DESTDIR/usr/local/share/man/man1
 CONFDIR=$DESTDIR/etc
 
 mkdir -p $BINDIR || true


### PR DESCRIPTION
Move installed files to a ```../local/..``` directory rather than the official distro directories.

Purpose: Even with sudo, OSX 10.11 prevents installation to ```/usr/bin``` and ```/usr/share```, you must install to ```/usr/local/...```