### PR TITLE
Add   conf.ip  for   "ip"   command

### DIFF
--- a/conf.ip
+++ b/conf.ip
@@ -1,0 +1,33 @@
+# ip number
+regexp=\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}
+colours=magenta
+-
+# parenthesis
+regexp=\(|\)
+colours=yellow
+-
+
+# dev wlan0 etc
+regexp=dev \w+
+colours=yellow
+-
+
+# "default"
+regexp=default
+colours=on_blue
+-
+
+# ip range size
+regexp=/\d{1,2}
+colours=red
+-
+
+# "linkdown"
+regexp=linkdown
+colours=bold red
+- 
+
+# "src"
+regexp=src \S+
+colours=on_magenta
+


### PR DESCRIPTION
This adds colouring for the "ip" command.

I optimised it for the call "ip r" (show local routing table), but colourings should
be helpful for other parameters and modi too.

It could also be helpful for the route command, I didn't test.

About regexes: I'm used too perl regexes and it seems like python regexes are fully compatible :) [1]
Perhaps a good info for contributors and the README.

Links:
[1] https://docs.python.org/2/howto/regex.html