### PR TITLE
Traceroute6 and others

### DIFF
--- a/grc.bashrc
+++ b/grc.bashrc
@@ -13,6 +13,7 @@ then
     alias netstat='colourify netstat'
     alias ping='colourify ping'
     alias traceroute='colourify /usr/sbin/traceroute'
+    alias traceroute6='colourify traceroute6'
     alias head='colourify head'
     alias tail='colourify tail'
     alias dig='colourify dig'

--- a/grc.bashrc
+++ b/grc.bashrc
@@ -12,7 +12,7 @@ then
     alias ld='colourify ld'
     alias netstat='colourify netstat'
     alias ping='colourify ping'
-    alias traceroute='colourify /usr/sbin/traceroute'
+    alias traceroute='colourify traceroute'
     alias traceroute6='colourify traceroute6'
     alias head='colourify head'
     alias tail='colourify tail'

--- a/grc.bashrc
+++ b/grc.bashrc
@@ -20,5 +20,6 @@ then
     alias mount='colourify mount'
     alias ps='colourify ps'
     alias mtr='colourify mtr'
+    alias ifconfig='colourify ifconfig'
     alias df='colourify df'
 fi


### PR DESCRIPTION
This pull request adds traceroute6 alias, ifconfig alias, and removes absolute path from /usr/sbin/traceroute since some distros (i.e. Slackware) put it on /usr/bin instead.

Feel free to cherry pick, or let me know if you want me to split it up.

Thanks :)
