### PR TITLE
Support the XDG Base Directory Specification

### DIFF
--- a/grc
+++ b/grc
@@ -71,10 +71,17 @@ if stdoutf == 1:
 
 conffile = None
 if cfile == "":
-    home = []
-    if 'HOME' in os.environ:
-        home = [os.environ['HOME']+"/.grc/grc.conf"]
-    conffilenames = home + ["/etc/grc.conf"]
+    home = os.environ.get('HOME')
+    xdg  = os.environ.get('XDG_CONFIG_HOME')
+    if not xdg and home:
+        xdg = home + '/.config'
+
+    conffilenames = []
+    if xdg:
+        conffilenames += [xdg + '/grc/grc.conf']
+    if home:
+        conffilenames += [home + '/.grc/grc.conf']
+    conffilenames += ['/usr/local/etc/grc.conf', '/etc/grc.conf']
     for i in conffilenames:
         if os.path.isfile(i):
             conffile = i

--- a/grc.conf
+++ b/grc.conf
@@ -11,7 +11,7 @@ conf.log
 conf.configure
 
 # ping command
-(^|[/\w\.]+/)ping6?\s
+(^|[/\w\.]+/)o?ping6?\s
 conf.ping
 
 # traceroute command

--- a/grcat
+++ b/grcat
@@ -84,9 +84,22 @@ def get_colour(x):
 
 home = []
 conffile = None
-if 'HOME' in os.environ:
-    home = [os.environ['HOME']+"/.grc/"]
-conffilepath = [""] + home + ["/usr/local/share/grc/", "/usr/share/grc/"]
+xdg_config = os.environ.get('XDG_CONFIG_HOME')
+xdg_data = os.environ.get('XDG_DATA_HOME')
+home = os.environ.get('HOME')
+if home and not xdg_config:
+    xdg_config = home + '/.config'
+if home and not xdg_data:
+    xdg_data = home + '/.local/share'
+
+conffilepath = [""]
+if xdg_data:
+    conffilepath += [xdg_data + '/grc/']
+if xdg_config:
+    conffilepath += [xdg_config + '/grc/']
+if home:
+    conffilepath += [home + '/.grc/']
+conffilepath += ['/usr/local/share/grc/', '/usr/share/grc/']
 if len(sys.argv) != 2:
     sys.stderr.write("You are not supposed to call grcat directly, but the usage is: grcat conffile\n")
     sys.exit(1)


### PR DESCRIPTION
Search for config file in `${XDG_CONFIG_HOME}/.grc` (or `~/.config/grc` when the variable is not set).
The directory `~/.grc` is still supported as a fallback, so this change is backwards-compatible.

I also made it so the configuration file is looked at `/usr/local/etc` in addition to `/etc`.