### PR TITLE
Added 'concat' option for appending matches to a file

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -26,7 +26,7 @@ Each entry consists of several lines.
 
 Each line has form: `keyword=value`
 
-where keyword is one of: regexp, colours, command, skip, replace, count
+where keyword is one of: regexp, colours, command, concat, skip, replace, count
 
 Only regexp is mandatory, but it does not have much sense by itself unless you specify at least a colour, skip, replace or command keyword as well.
 
@@ -43,6 +43,8 @@ Yet another special name is an arbitrary string enclosed in straight quotes. Thi
 This is useful on a 256-colour enabled xterm, where e.g.  `colours="\033[38;5;22m"` will give you a dark green (inspired by Rutger Ovidius). Caveat: the string cannot contain a comma. This is due to my laziness :-)
 
 **command** is command to be executed when regexp matches. Its output will be mixed with normal stdout, use redirectors (`>/dev/null`) if you want to suppress it.
+
+**concat** is the name of a file which the current line will be appended to when the regexp matches.
 
 **skip** can be `skip=yes`, if that case the matched line is skipped (discarded from the output), or `skip=no`, when it is not skipped. Default (if you do not have skip keyword) is of course not skipped.
 

--- a/grcat
+++ b/grcat
@@ -130,7 +130,7 @@ while not is_last:
         keyword = lower(keyword)
         if keyword in  ('colors', 'colour', 'color'):
             keyword = 'colours'
-        if not keyword in ["regexp", "colours", "count", "command", "skip", "replace"]:
+        if not keyword in ["regexp", "colours", "count", "command", "skip", "replace", "concat"]:
             raise ValueError("Invalid keyword")
         ll[keyword] = value
 
@@ -210,6 +210,11 @@ while 1:
                     else:
                         prevcount = "once"
                         pos = len(line)
+                if 'concat' in pattern:
+                    with open(pattern['concat'], 'a') as f :
+                        f.write(line + '\n')
+                    if 'colours' not in pattern:
+                        break
                 if 'command' in pattern:
                     os.system(pattern['command'])
                     if 'colours' not in pattern:

--- a/grcat.1
+++ b/grcat.1
@@ -25,6 +25,7 @@ where keyword is one of:
 .BR regexp ",
 .BR colours ",
 .BR command ",
+.BR concat ",
 .BR skip ",
 .BR count ".
 Only


### PR DESCRIPTION
This is primarily intended to produce _errors_ and _warning_ files that can be opened with
`vim -q errors.txt`

This allows us to build large projects from the command line, filtering out certain errors and warnings into files that we can investigate afterwards when necessary, without building directly from vim.