### PR TITLE
configuration for ant and maven

### DIFF
--- a/conf.ant
+++ b/conf.ant
@@ -1,0 +1,46 @@
+# ant grc colorizer configuration
+# BUILD FAILED
+regexp=BUILD FAILED
+colours=bold red
+count=more
+==============
+# BUILD SUCCESSFUL
+regexp=^BUILD SUCCESSFUL
+colours=bold green
+count=more
+==============
+# Total time
+regexp=^(Total time: )([\d]+.*)$
+colours=yellow,bold magenta
+count=more
+===============
+# some error
+regexp=[\d]+ error[s]?
+colours=red
+count=more
+==============
+# some warning
+regexp=[\d]+ warning[s]?
+colours=yellow
+count=more
+===============
+# some error
+regexp=[Ee]rror:
+colours=red
+count=more
+==============
+# some warning
+regexp=[Ww]arning:
+colours=yellow
+count=more
+==============
+# project name
+regexp=^[^:\s]+:$
+colours=green
+count=more
+==============
+# products
+regexp=[^/]+\.[ewrj]ar$
+colours=blue
+count=more
+

--- a/conf.mvn
+++ b/conf.mvn
@@ -24,42 +24,42 @@ regexp=^\[debug\]
 colours=magenta
 count=more
 ==============
-# linijki [INFO] ----
+# lines [INFO] ----
 regexp=\s[-]{6,}
 colours=red
 count=more
 ==============
-# linijki ^----
+# lines ^----
 regexp=^[-]{6,}
 colours=yellow
 count=more
 ==============
-# linijki  T E S T S
+# lines  T E S T S
 regexp=^ T E S T S
 colours=yellow
 count=more
 ==============
-# linijki ^Tests run:
+# lines ^Tests run:
 regexp=^Tests run: ([\d]+)
 colours=yellow,green
 count=more
 ==============
-# linijki ^Tests run: Failures/Errors/Skipped
+# lines ^Tests run: Failures/Errors/Skipped
 regexp=(Failures|Errors|Skipped):\s([\d]+)
 colours=none,yellow,bold red
 count=more
 ==============
-# linijki ^Tests run: Failures/Errors/Skipped
+# lines ^Tests run: Failures/Errors/Skipped
 regexp=(Failures|Errors|Skipped):\s(0)\D?
 colours=none,yellow,green
 count=more
 ==============
-# podsumowanie
+# summary
 regexp=\s(Total time: )(.*)$
 colours=none,none,bold yellow
 count=more
 ==============
-# podsumowanie
+# summary
 regexp=\s(Finished at: )(.*)$
 colours=none,none,bold yellow
 count=more

--- a/conf.mvn
+++ b/conf.mvn
@@ -1,0 +1,92 @@
+# mvn grc colorizer configuration
+# [INFO]
+regexp=^\[INFO\]
+colours=bold
+count=more
+==============
+# [WARNING]
+regexp=^\[WARNING\]
+colours=bold yellow
+count=more
+==============
+# [ERROR]
+regexp=^\[ERROR\]
+colours=bold red
+count=more
+==============
+# BUILD FAILURE
+regexp=BUILD FAILURE
+colours=bold red
+count=more
+==============
+# [debug]
+regexp=^\[debug\]
+colours=magenta
+count=more
+==============
+# linijki [INFO] ----
+regexp=\s[-]{6,}
+colours=red
+count=more
+==============
+# linijki ^----
+regexp=^[-]{6,}
+colours=yellow
+count=more
+==============
+# linijki  T E S T S
+regexp=^ T E S T S
+colours=yellow
+count=more
+==============
+# linijki ^Tests run:
+regexp=^Tests run: ([\d]+)
+colours=yellow,green
+count=more
+==============
+# linijki ^Tests run: Failures/Errors/Skipped
+regexp=(Failures|Errors|Skipped):\s([\d]+)
+colours=none,yellow,bold red
+count=more
+==============
+# linijki ^Tests run: Failures/Errors/Skipped
+regexp=(Failures|Errors|Skipped):\s(0)\D?
+colours=none,yellow,green
+count=more
+==============
+# podsumowanie
+regexp=\s(Total time: )(.*)$
+colours=none,none,bold yellow
+count=more
+==============
+# podsumowanie
+regexp=\s(Finished at: )(.*)$
+colours=none,none,bold yellow
+count=more
+==============
+# BUILD SUCCESSFUL
+regexp=\s(BUILD SUCCESSFUL)
+colours=none,green bold
+count=more
+==============
+# Building projectName
+regexp=^(\[INFO\])( Building )(.*)$
+colours=none,bold,none,white bold
+count=more
+==============
+# reactor summary
+regexp=([.]{3,} )(SUCCESS)( \[)([^\]]*)(])
+colours=none,none,green,none,yellow,none
+count=more
+==============
+# reactor summary
+regexp=([.]{3,} )(FAILURE)( \[)([^\]]*)(])
+colours=none,none,red,none,red,none
+count=more
+==============
+# reactor summary
+regexp=([.]{3,} )(SKIPPED)
+colours=none,none,yellow bold,none
+count=more
+
+

--- a/grc.conf
+++ b/grc.conf
@@ -238,3 +238,11 @@ conf.getfacl
 (^|[/\w\.]+/)showmount\s?
 conf.showmount
 
+# apache ant command
+(^|[/\w\.]+/)ant\s?
+conf.ant
+
+# # apache maven command
+(^|[/\w\.]+/)mvn\s?
+conf.mvn
+


### PR DESCRIPTION
Configuration for Apache Ant and Apache Maven building systems.

This is how maven build looks with colorizing:
![mvn-example](https://cloud.githubusercontent.com/assets/13992009/20625742/8a6b29c6-b315-11e6-93d6-ca3673049c9c.png)

