### PR TITLE
Use bash internal functionalities for grc detection

### DIFF
--- a/grc.bashrc
+++ b/grc.bashrc
@@ -1,6 +1,5 @@
-GRC=`which grc`
-if [ "$TERM" != dumb ] && [ -n "$GRC" ]
-then
+GRC="$(type -p grc)"
+if [ "$TERM" != dumb ] && [ -n "$GRC" ]; then
     alias colourify="$GRC -es --colour=auto"
     alias configure='colourify ./configure'
     alias diff='colourify diff'


### PR DESCRIPTION
which is an external tool, where as type is a bash internal funciton
and always available

Signed-off-by: Justin Lecher <jlec@gentoo.org>