### PR TITLE
flush grcat line writes

### DIFF
--- a/grcat
+++ b/grcat
@@ -273,7 +273,7 @@ while 1:
                 clineprev = cline[i]
         nline = nline + colours['default']
         try:
-            print(nline)
+            print(nline, flush=True)
         except IOError as e:
             if e.errno == errno.EPIPE:
                 break


### PR DESCRIPTION
I used `grc` in a Docker container that runs go tests. I have a configuration that correctly colorizes my tests. However, the output of `grc go test -v` does not get written until the tests all finish, unless the container is run with a TTY. Adding `flush=True` to the print function in `grcat` causes the output to be written out line-by-line as lines become available without a TTY. 

I don't know how this affects things like performance or what side effects it has. You may want to instead write a patch that gates this behavior behind a flag. I'm not sure what the correct behavior is. I'm using this fork for my stuff and it works fine for me.