### PR TITLE
Fixed getsebool typo

### DIFF
--- a/grc.bashrc
+++ b/grc.bashrc
@@ -36,7 +36,7 @@ if [ "$TERM" != dumb ] && [ -n "$GRC" ]; then
     alias ps='colourify ps'
     alias mtr='colourify mtr'
     alias semanage='colourify semanage'
-    alias getsebool='colourify setsebool'
+    alias getsebool='colourify getsebool'
     alias ifconfig='colourify ifconfig'
 fi
 


### PR DESCRIPTION
fixed typo on getsebool which was aliased to setsebool
alias getsebool='colourify setsebool'