### PR TITLE
Support ZSH auto-completion

### DIFF
--- a/_grc
+++ b/_grc
@@ -1,0 +1,25 @@
+#compdef grc
+
+setopt localoptions extended_glob
+
+local environ e cmd
+local -a args
+local -a _comp_priv_prefix
+
+zstyle -a ":completion:${curcontext}:" environ environ
+
+for e in "${environ[@]}"
+do local -x "$e"
+done
+
+args=(
+  '(-e --stderr)'{-e,--stderr}'[redirect stderr; do not automatically redirect stdout]'
+  '(-s --stdout)'{-s,--stdout}'[redirect stdout; even with -e/--stderr]'
+  '(-c <name>--config=<name>)'{-c+,--config=-}'[use <name> as configuration file for grcat]:file:_files'
+  '--color=-[colo?urize output]:color:(on off auto)'
+  '(-h --help)'{-h,--help}'[display help message and exit]'
+  '--pty[run command in pseudotermnial (experimental)]'
+  '*::arguments:{ _normal }'
+)
+
+_arguments -s $args

--- a/grc.zsh
+++ b/grc.zsh
@@ -1,6 +1,4 @@
 if [[ "$TERM" != dumb ]] && (( $+commands[grc] )) ; then
-  # Prevent grc aliases from overriding zsh completions.
-  setopt COMPLETE_ALIASES
 
   # Supported commands
   cmds=(

--- a/install.sh
+++ b/install.sh
@@ -25,4 +25,5 @@ cp -fv grc.zsh $CONFDIR
 cp -fv grc.fish $CONFDIR
 mkdir -p $PROFILEDIR
 cp -fv grc.bashrc $PROFILEDIR
-
+mkdir -p $PREFIX/zsh/site-functions
+cp -fv _grc $PREFIX/zsh/site-functions


### PR DESCRIPTION
Using the `_sudo` function as a reference, I have written a completion function for grc.  This is helpful not only when calling grc directly, but when Zsh resolves completions for aliases.  We can now unset COMPLETE_ALIASES, which allows Zsh's completion system to be used to its fullest.