### PR TITLE
Fix color files

### DIFF
--- a/colourfiles/conf.common
+++ b/colourfiles/conf.common
@@ -1,0 +1,11 @@
+# Green Words
+regexp=[Ee]nabled?|[Oo]k|[Rr]unning|[Tt]rue
+colour=green
+-
+# Red Words
+regexp=[Dd]isabled?|[Ee]rrors?|[Ss]topped|[Ff]alse
+colour=red
+-
+# Yellow Words
+regexp=[Ww]arning
+colour=yellow

--- a/colourfiles/conf.dig
+++ b/colourfiles/conf.dig
@@ -1,31 +1,23 @@
-#ipv6
-regexp=(([0-9a-fA-F]{1,4})?\:\:?[0-9a-fA-F]{1,4})+
-colours=green
-=======
-#time
-regexp=\s[0-9]{1,6}\s
-colours=red
-=======
-#type
-regexp=[A-Z]{1,4}
-colours=cyan
-=======
-#in
-regexp=(IN|CH)
-colours=yellow
-=======
 #domain
-regexp=[a-z0-9-]+\.
-colours=magenta
-=======
-#ip address
+regexp=[\S]+\.
+colours=bright_magenta
+-
+#line
+regexp=^(\S+).*?(\d+)\t(\w+)\t(\w+)\t
+colours=unchanged,magenta,red,yellow,cyan
+-
+#ip4 address
 regexp=\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}
 colours=green
-=======
+-
+#ipv6
+regexp=\t(([0-9a-fA-F]{1,4})?\:\:?[0-9a-fA-F]{1,4})+
+colours=dark green
+-
 #comments
-regexp=^;;\s\w*\s*\w*
+regexp=^;;[\s\w]+
 colours=yellow
-=======
+-
 #Title
-regexp=; <<>> DiG (\d+\.\d+\.\d+).*<<>>\s(\S+)$
-colours=default,green,bold magenta
+regexp=; <<>> DiG.* <<>> (\S+)
+colours=default,bold magenta

--- a/colourfiles/conf.ipaddr
+++ b/colourfiles/conf.ipaddr
@@ -4,7 +4,11 @@ colours=default,bold yellow,bold magenta
 =====
 # broadcast
 regexp=brd\s([^}s]+)
-colours=default,dark
+colours=default,dark cyan
+=====
+# dynamic
+regexp=\bdynamic\b
+colours=dark green
 =====
 # IP6
 regexp=inet6\s([^\/]+)\/(\d+)
@@ -33,6 +37,10 @@ colours=default,bright_white,bold cyan,cyan
 # < >
 regexp=\s<([^>]+)>
 colours=default,cyan
+=====
+# NO-CARRIER
+regexp=NO-CARRIER
+colours=bold red
 =====
 # Master dev
 regexp=\smaster\s(\S+)\s

--- a/colourfiles/conf.iproute
+++ b/colourfiles/conf.iproute
@@ -22,6 +22,10 @@ colours=default,magenta,bold magenta
 regexp=(proto)\s(\S+)\s
 colours=default,default,dark yellow
 =====
+# metric
+regexp=(metric)\s(\d+)\b
+colours=default,default,bold white
+=====
 # linkdown
 regexp=linkdown
 colours=bold red

--- a/colourfiles/conf.uptime
+++ b/colourfiles/conf.uptime
@@ -1,9 +1,9 @@
-# Time
-regexp=\sup(?:\s(\d+ days?),)?\s+(\d+ min|\d+:\d+),
-colours=default,yellow,green
+# Regular Up
+regexp=\sup(?: (\d+) days?,)? +(\d+ min|\d+:\d+)(?=,)
+colours=green,bold green, bold green
 -
 # users
-regexp=\s+(\d+)\susers
+regexp=\b(\d+) users?
 colours=yellow,bold yellow
 -
 # load average


### PR DESCRIPTION
This commit fix colors for dig, ip addr, ip route, and uptime commands. 
Adds a common color file for commands where some statuses can be highlighted in gree, red, yellow colors. This was tested with kubectl and minikube commands, but can be used with many others. This common file was purposely left out of config files.