### PR TITLE
Add docker-compose to the shell init files

### DIFF
--- a/grc.bashrc
+++ b/grc.bashrc
@@ -6,6 +6,7 @@ if [ "$TERM" != dumb ] && [ -n "$GRC" ]; then
     alias df='colourify df'
     alias diff='colourify diff'
     alias docker='colourify docker'
+    alias docker-compose='colourify docker-compose'
     alias docker-machine='colourify docker-machine'
     alias du='colourify du'
     alias env='colourify env'

--- a/grc.fish
+++ b/grc.fish
@@ -8,7 +8,7 @@
 
 set -U grc_plugin_execs cat cvs df diff dig gcc g++ ls ifconfig \
        make mount mtr netstat ping ps tail traceroute \
-       wdiff blkid du dnf docker docker-machine env id ip iostat \
+       wdiff blkid du dnf docker docker-compose docker-machine env id ip iostat \
        last lsattr lsblk lspci lsmod lsof getfacl getsebool ulimit uptime nmap \
        fdisk findmnt free semanage sar ss sysctl systemctl stat showmount \
        tcpdump tune2fs vmstat w who

--- a/grc.zsh
+++ b/grc.zsh
@@ -8,6 +8,9 @@ if [[ "$TERM" != dumb ]] && (( $+commands[grc] )) ; then
     df \
     diff \
     dig \
+    docker \
+    docker-compose \
+    docker-machine \
     gcc \
     gmake \
     ifconfig \


### PR DESCRIPTION
I would like to wrap the [`docker-compose` command](https://github.com/garabik/grc/blob/master/grc.conf#L172) in the colourizer, so its output is automatically colourized, just like `docker`.

This should get rid of the cognitive overhead of having `grc docker-compose ps` vs. `docker ps`