### PR TITLE
Update logfile config

### DIFF
--- a/colourfiles/conf.log
+++ b/colourfiles/conf.log
@@ -16,14 +16,14 @@ regexp=.*last message repeated \d+ times$
 colours=yellow
 count=stop
 ======
-# this is date
+# this is a date
 regexp=^... (\d| )\d \d\d:\d\d:\d\d(\s[\w\d]+?\s)
 colours=green, green, red
 count=once
 ======
 # everything in parentheses
 regexp=\(.+?\)
-colours=green
+colours=blue
 count=more
 ======
 # everything in `'
@@ -31,9 +31,18 @@ regexp=\`.+?\'
 colours=bold yellow
 count=more
 ======
+# everything in "
+regexp=\".+?\"
+colours=blue
+======
 # this is probably a pathname
-regexp=/[\w/\.]+
-colours=bold green
+regexp=\s/[a-zA-Z_/\.\-\?\d\=\&]+
+colours=blue
+count=more
+======
+# everything in <>
+regexp=\<.*?\>
+colours=blue
 count=more
 ======
 # name of process and pid
@@ -41,13 +50,44 @@ regexp=([\w/\.\-]+)(\[\d+?\])
 colours=bold blue, bold red
 count=more
 ======
-# ip number
+# IPv4
 regexp=\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}
-colours=bold magenta
+colours=bold yellow
 count=more
+======
+# IPv6
+regexp=\d(([0-9a-fA-F]{1,4})?\:\:?[0-9a-fA-F]{1,4})+
+colours=bold yellow
+=======
+# Email address
+regexp=[a-zA-z0-9\.\-\+]+\@[\w\-\.]+
+colours=green
+======
+# HTTP verbs
+regexp=GET|POST|PUT|DELETE|PATCH|HEAD
+colours=green
+======
+# 2xx status
+regexp=\s\b2\d{2}\b\s
+colours=green
+======
+# 3xx status
+regexp=\s\b3\d{2}\b\s
+colours=yellow
+======
+# 4xx status
+regexp=\s\b4\d{2}\b\s
+colours=red
+======
+# 5xx status
+regexp=\s\b5\d{2}\b\s
+colours=red
+======
+# status deferred
+regexp=status\=deferred|Connection refused
+colours=red
 ======
 # connect requires special attention
 regexp=connect
 colours=on_red
 count=more
-


### PR DESCRIPTION
This commit refines how logfiles are displayed, so it is more suitable for webserver and mailserver logs in addition to generic kernel messages:

* Add colorization of strings in double quotes
* Alter parsing of pathnames to also include common URL path components
* Mark IPv4 and IPv6 addresses
* Detect email addresses
* Detect HTTP verbs and common HTTP and mailserver status codes

I think it is rather nice to look at and easy to visually parse important parts of each log line. Since I've been using this config for a long time on my servers I thought I should give back and make it available to the public.

Merge if you feel like it, if not it is here to copy for anyone that wants to. Thanks @garabik for your awesome tool!