### PR TITLE
Added config for sensors command

### DIFF
--- a/colourfiles/conf.sensors
+++ b/colourfiles/conf.sensors
@@ -1,12 +1,28 @@
-# Adapetr
-regexp=Adapter:\s(.*)
-colours=default, green
+# Sensor name
+regexp=([a-z\-0-9]+)
+colours=underline yellow
 ======
-# High temperature
-regexp=.+:\s+(\+[67][0-9][^0-9])
-colours=default, red
+# Data names
+regexp=(.+:)\s+(.+)
+colours=unchanged, bright_cyan, default
 ======
-# Very high temperature
-regexp=.+:\s+(\+[89][0-9][0-9]?)
-colours=default, blink red
+# Extra info
+regexp=.+\s+(\(.+\))
+colours=unchanged, bright_black
+======
+# Adapter name
+regexp=Adapter:(\s.*)
+colours=unchanged, yellow
+======
+# Low temperature (below 60)
+regexp=.+:\s+(\+[2345][0-9]\.[0-9]°C)
+colours=unchanged, green
+======
+# High temperature (above 60)
+regexp=.+:\s+(\+[67][0-9]\.[0-9]°C)
+colours=unchanged, bright_yellow
+======
+# Very high temperature (above 80)
+regexp=.+:\s+(\+[89][0-9]\.[0-9]°C)
+colours=unchanged, bright_red
 ======

--- a/grc.conf
+++ b/grc.conf
@@ -287,3 +287,6 @@ conf.lolcat
 (^|[/\w\.]+/)whois\s?
 conf.whois
 
+# sensors command
+(^|[/\w\.]+/)sensors\s?
+conf.sensors 


### PR DESCRIPTION
There was a config for the command `sensors` already, but it wasn't registered in the main config and it didn't really add much color. I've added it to `grc.conf` and thrown in a few more colors.

Since I couldn't find anything about a specific color scheme that commands should use, I just sort of did whatever. Here's what it looks like on my always-overheating server:

![screenshot_20181009_205117](https://user-images.githubusercontent.com/3891092/46692768-60c30b80-cc08-11e8-8439-4e7bbd565557.png)
