### PR TITLE
iwconfig : Bit Rate can contain dots : Bit Rate=43.3 Mb/s

### DIFF
--- a/colourfiles/conf.iwconfig
+++ b/colourfiles/conf.iwconfig
@@ -11,7 +11,7 @@ regexp=802\.11([a-z]+)
 colours=bold yellow
 =======
 # Speed
-regexp=[0-9]+ Mb/s
+regexp=[0-9\.]+ Mb/s
 colours=bold yellow
 =======
 # Tx-Power


### PR DESCRIPTION
Hi

On stretch debian, iwconfig shows : 
```
enp1s0    no wireless extensions.

lo        no wireless extensions.

enp3s0    no wireless extensions.

wlx002275d82e09  IEEE 802.11  ESSID:"CFA_UTEC"
          Mode:Managed  Frequency:2.412 GHz  Access Point: 00:59:DC:89:D2:A0
          Bit Rate=43.3 Mb/s   Tx-Power=20 dBm
          Retry short  long limit:2   RTS thr:off   Fragment thr:off
          Power Management:off
          Link Quality=35/70  Signal level=-75 dBm
          Rx invalid nwid:0  Rx invalid crypt:0  Rx invalid frag:0
          Tx excessive retries:0  Invalid misc:0   Missed beacon:0

```
Then Bit Rate can contain dots.
