### PR TITLE
Fix zsh completions if --colour is used

### DIFF
--- a/_grc
+++ b/_grc
@@ -16,7 +16,7 @@ args=(
   '(-e --stderr)'{-e,--stderr}'[redirect stderr; do not automatically redirect stdout]'
   '(-s --stdout)'{-s,--stdout}'[redirect stdout; even with -e/--stderr]'
   '(-c <name>--config=<name>)'{-c+,--config=-}'[use <name> as configuration file for grcat]:file:_files'
-  '--color=-[colo?urize output]:color:(on off auto)'
+  '--colour=-[colourize output]:colour:(on off auto)'
   '(-h --help)'{-h,--help}'[display help message and exit]'
   '--pty[run command in pseudotermnial (experimental)]'
   '*::arguments:{ _normal }'


### PR DESCRIPTION
"color" was used in the zsh completion, which means `grc --colour=auto docker` won't complete because of it. 