### PR TITLE
use regex library for recursion support

### DIFF
--- a/grc
+++ b/grc
@@ -2,7 +2,7 @@
 
 from __future__ import print_function
 
-import os, re, string, sys, getopt, signal
+import os, regex as re, string, sys, getopt, signal
 
 
 def version():

--- a/grcat
+++ b/grcat
@@ -2,7 +2,7 @@
 
 from __future__ import print_function
 
-import sys, os, string, re, signal, errno
+import sys, os, string, regex as re, signal, errno
 
 #some default definitions
 colours = {


### PR DESCRIPTION
for recursion support it would be awesome to use the regex instead of std lib.
this would introduce a pip dependency though. not sure how to handle this?

recursion support would be nice to capture and color nested parenthesis lines, e.g.:
`27.03.2019 10:42:27.275 *INFO* [FelixStartLevel [Thread-232]] org.apache.sling.commons.threads.impl.DefaultThreadPool Thread pool [DAM Transporter] initialized.`

Using regex: `\[([^\[\]]+|(?R))*\]`

Which matches: `[FelixStartLevel [Thread-232]]` and `[DAM Transporter]`