### PR TITLE
conf.uptime: Support decimal comma

### DIFF
--- a/colourfiles/conf.uptime
+++ b/colourfiles/conf.uptime
@@ -7,7 +7,7 @@ regexp=\s+(\d+)\susers
 colours=yellow,bold yellow
 -
 # load average
-regexp=load average: (\d+\.\d+),\s(\d+\.\d+),\s(\d+\.\d+)
+regexp=load average: (\d+[\.,]\d+),\s(\d+[\.,]\d+),\s(\d+[\.,]\d+)
 colours=default,bright_cyan,cyan,dark cyan
 -
 # W Command section


### PR DESCRIPTION
So load averages also are colourised when e.g. LANG=es_ES