### PR TITLE
grc.conf : command ip :

### DIFF
--- a/grc.conf
+++ b/grc.conf
@@ -99,18 +99,18 @@ conf.df
 conf.du
 
 # ip addr/link
-(^|[/\w\.]+/)ip a(ddr)*\s?
+(^|[/\w\.]+/)ip( -\w+)* a(d(d(r(e(ss?)?)?)?)?)?\b
 conf.ipaddr
 
-(^|[/\w\.]+/)ip ?(-.)* ?l(ink)*\s?
+(^|[/\w\.]+/)ip( -\w+)* l(i(nk?)?)?\b
 conf.ipaddr
 
 # ip route
-(^|[/\w\.]+/)ip r(oute)*\s?
+(^|[/\w\.]+/)ip( -\w+)* r(o(u(te?)?)?)?\b
 conf.iproute
 
 # ip neighbor
-(^|[/\w\.]+/)ip n(eighbor)*\s?
+(^|[/\w\.]+/)ip( -\w+)* n(e(i(g(h(b(o(ur?)?)?)?)?)?)?)?\b
 conf.ipneighbor
 
 # ip command - rest of commands


### PR DESCRIPTION
	- accept parameters between "ip" and main parameter
	- accept all correct syntax of "address" ("a", "ad", "add", "addr", "addre",...,"address")
	- do the the same with "link", "route" and "neighbour"