### PR TITLE
Update conf.dockerps

### DIFF
--- a/colourfiles/conf.dockerps
+++ b/colourfiles/conf.dockerps
@@ -17,8 +17,20 @@ colours=blue
 # Statuses
 # https://github.com/docker/docker/blob/e5a3f86e447dd659da3c2e759f3c088a0bfcfe3d/container/state.go#L40
 # Up
-regexp=(?:\s{2}|^)(?:Up|Restarting)(?:(?:\s[\w,\d,(,)]+)+)?
+regexp=(?:\s{2}|^)(?:Up|Restarting)(?:(?:\s[\w,\d]+)+)?
 colours=bold green
+======
+# Health - healthy
+regexp=\s\(healthy\)
+colours=bold green
+======
+# Health -  starting
+regexp=\s\(health: starting\)
+colours=bold yellow
+======
+# Health - unhealthy
+regexp=\s\(unhealthy\)
+colours=bold red
 ======
 # Statuses - Exited
 regexp=Exited\s.(\d+).+?(?=\s{2,})


### PR DESCRIPTION
Fixes #148 

Color statuses to call out starting and unhealthy containers.

![image](https://user-images.githubusercontent.com/387006/84204565-717cf200-aa79-11ea-89ad-df351adb52c8.png)
