### PR TITLE
Update grc.zsh

### DIFF
--- a/grc.zsh
+++ b/grc.zsh
@@ -2,30 +2,45 @@ if [[ "$TERM" != dumb ]] && (( $+commands[grc] )) ; then
 
   # Supported commands
   cmds=(
+    as \
+    blkid \
     cc \
     configure \
-    cvs \
     df \
-    diff \
     dig \
+    diff \
+    docker \
+    docker-machine \
+    du \
+    env \
+    free \
+    fdisk \
+    findmnt \
+    g++ \
     gcc \
-    gmake \
+    getsebool \
+    head \
+    id \
     ifconfig \
-    last \
-    ldap \
+    ip \
+    iptables \
+    gas \
+    ld \
     ls \
+    lsof \
+    lsblk \
+    lspci \
     make \
     mount \
     mtr \
     netstat \
     ping \
-    ping6 \
     ps \
+    semanage \
     traceroute \
     traceroute6 \
-    wdiff \
+    tail \
     whois \
-    iwconfig \
   );
 
   # Set alias for available commands.


### PR DESCRIPTION
Fixes #100

Makes `grc.zsh` consistent with `grc.bashrc` in commands.
Although, there should be a better way (create grc.zsh and grc.bashrc from a template?).