### PR TITLE
Add support for `go test`

### DIFF
--- a/colourfiles/conf.go-test
+++ b/colourfiles/conf.go-test
@@ -1,0 +1,21 @@
+# go-test grc colorizer configuration
+regexp==== RUN .*
+colour=bright_blue
+-
+regexp=--- PASS: .* (\(\d+\.\d+s\))
+colour=green, yellow
+-
+regexp=^PASS$
+colour=bold white on_green
+-
+regexp=^(ok|FAIL)\s+.*
+colour=default, magenta
+-
+regexp=--- FAIL: .* (\(\d+\.\d+s\))
+colour=red, yellow
+-
+regexp=^FAIL$
+colour=bold white on_red
+-
+regexp=[^\s]+\.go(:\d+)?
+colour=cyan

--- a/grc.conf
+++ b/grc.conf
@@ -287,3 +287,7 @@ conf.lolcat
 (^|[/\w\.]+/)whois\s?
 conf.whois
 
+# go test
+(^|[/\w\.]+/)go test\s?
+conf.go-test
+


### PR DESCRIPTION
Fixes #122.

Adds support for `go test`.

![image](https://user-images.githubusercontent.com/387006/84266565-b3964a00-aaf2-11ea-9b8f-a01eaa3b93a0.png)

![image](https://user-images.githubusercontent.com/387006/84266587-bbee8500-aaf2-11ea-9cd9-22cddcbb6578.png)
