### PR TITLE
Flatten and clean up syntax in zsh script

### DIFF
--- a/grc.zsh
+++ b/grc.zsh
@@ -1,40 +1,41 @@
-if [[ "$TERM" != dumb ]] && (( $+commands[grc] )) ; then
-
-  # Supported commands
-  cmds=(
-    cc \
-    configure \
-    cvs \
-    df \
-    diff \
-    dig \
-    gcc \
-    gmake \
-    ifconfig \
-    last \
-    ldap \
-    ls \
-    make \
-    mount \
-    mtr \
-    netstat \
-    ping \
-    ping6 \
-    ps \
-    traceroute \
-    traceroute6 \
-    wdiff \
-    whois \
-    iwconfig \
-  );
-
-  # Set alias for available commands.
-  for cmd in $cmds ; do
-    if (( $+commands[$cmd] )) ; then
-      alias $cmd="grc --colour=auto $(whence $cmd)"
-    fi
-  done
-
-  # Clean up variables
-  unset cmds cmd
+if [[ "$TERM" = dumb ]] || (( ! $+commands[grc] )); then
+  return
 fi
+
+# Supported commands
+cmds=(
+  cc
+  configure
+  cvs
+  df
+  diff
+  dig
+  gcc
+  gmake
+  ifconfig
+  last
+  ldap
+  ls
+  make
+  mount
+  mtr
+  netstat
+  ping
+  ping6
+  ps
+  traceroute
+  traceroute6
+  wdiff
+  whois
+  iwconfig
+)
+
+# Set alias for available commands.
+for cmd in $cmds; do
+  if (( $+commands[$cmd] )) ; then
+    alias $cmd="grc --colour=auto $commands[$cmd])"
+  fi
+done
+
+# Clean up variables
+unset cmds cmd


### PR DESCRIPTION
`$commands[$cmd]` is set to the path to `$cmd`, so you can use that instead of whence. Also, array items can be separated by newlines, you don't need to escape them.