### PR TITLE
docker ps: ip addresses and ports colorization

### DIFF
--- a/colourfiles/conf.dockerps
+++ b/colourfiles/conf.dockerps
@@ -28,9 +28,13 @@ colours=bold red,red
 regexp=Restarting\s.(\d+).+?(?=\s{2,})
 colours=bold blue
 ======
-# Ip Addresses / Ports
-regexp=(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(\:)?(\d{1,5}))?(?:->)?(\d{1,5}(\/)\w+)
-colours=default,blue,default,bright_green,bright_blue,default
+# Ip Addresses 
+regexp=(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})(\:)?
+colours=default,blue,default
+======
+# Ports
+regexp=(\d{1,5})?(-)?(\d{1,5})?(->)?(\d{1,5})(-)?(\d{1,5})?(\/)(tcp|udp)
+colours=default,bright_green,default,bright_green, default, bright_green, default, bright_green, default, cyan
 ======
 # NAMES
 regexp=(?:([a-z\-_0-9]+)\/)*([a-z\-_0-9]+)$

--- a/colourfiles/conf.dockerps
+++ b/colourfiles/conf.dockerps
@@ -34,7 +34,7 @@ colours=default,blue,default
 ======
 # Ports
 regexp=(\d{1,5})?(-)?(\d{1,5})?(->)?(\d{1,5})(-)?(\d{1,5})?(\/)(tcp|udp)
-colours=default,bright_green,default,bright_green, default, bright_green, default, bright_green, default, cyan
+colours=default,bright_green,default,bright_green, default, bright_green,default,bright_green,default,cyan
 ======
 # NAMES
 regexp=(?:([a-z\-_0-9]+)\/)*([a-z\-_0-9]+)$


### PR DESCRIPTION
The old regex didn't like port ranges and a few other cases.

Unpatched/current formatting on top, patched below:

![image](https://user-images.githubusercontent.com/804039/100159352-e7510a80-2ead-11eb-85ad-8a4872ea6b22.png)
