### PR TITLE
grc.conf : configure command : same regular expression as the others

### DIFF
--- a/grc.conf
+++ b/grc.conf
@@ -7,7 +7,7 @@ conf.irclog
 conf.log
 
 # configure command
-(^|[/\w\.]+/)?configure
+(^|[/\w\.]+/)configure\b
 conf.configure
 
 # ping command


### PR DESCRIPTION
	- remove useless ? to have the same begin as the other
	- end with \b