### PR TITLE
conf.log : accept now empty string "" and empty parentheses ()

### DIFF
--- a/colourfiles/conf.log
+++ b/colourfiles/conf.log
@@ -24,7 +24,7 @@ colours=green, green, red
 count=once
 ======
 # everything in parentheses
-regexp=\(.+?\)
+regexp=\(.*?\)
 colours=blue
 count=more
 ======
@@ -34,7 +34,7 @@ colours=bold yellow
 count=more
 ======
 # everything in "
-regexp=\".+?\"
+regexp=\".*?\"
 colours=blue
 ======
 # this is probably a pathname


### PR DESCRIPTION
Example of file, from the command : lsblk -n -P -p -o HOTPLUG,MOUNTPOINT,STATE,NAME,TYPE,FSTYPE
>----------------------------
HOTPLUG="0" MOUNTPOINT="/usr/lib/live/mount/rootfs/filesystem.squashfs" STATE="" NAME="/dev/loop0" TYPE="loop" FSTYPE="squashfs"
HOTPLUG="0" MOUNTPOINT="" STATE="running" NAME="/dev/sda" TYPE="disk" FSTYPE=""
HOTPLUG="0" MOUNTPOINT="" STATE="" NAME="/dev/sda1" TYPE="part" FSTYPE="vfat"
HOTPLUG="0" MOUNTPOINT="" STATE="" NAME="/dev/sda2" TYPE="part" FSTYPE=""
HOTPLUG="0" MOUNTPOINT="" STATE="" NAME="/dev/sda3" TYPE="part" FSTYPE="ntfs"
HOTPLUG="1" MOUNTPOINT="" STATE="running" NAME="/dev/sdb" TYPE="disk" FSTYPE="iso9660"
HOTPLUG="1" MOUNTPOINT="/usr/lib/live/mount/medium" STATE="" NAME="/dev/sdb1" TYPE="part" FSTYPE="iso9660"
HOTPLUG="1" MOUNTPOINT="" STATE="" NAME="/dev/sdb2" TYPE="part" FSTYPE="vfat"
HOTPLUG="1" MOUNTPOINT="" STATE="running" NAME="/dev/sdd" TYPE="disk" FSTYPE="vfat"
HOTPLUG="1" MOUNTPOINT="" STATE="running" NAME="/dev/sr0" TYPE="rom" FSTYPE=""
<----------------------------

lsblk -n -P -p -o HOTPLUG,MOUNTPOINT,STATE,NAME,TYPE,FSTYPE | grcat conf.log
