### PR TITLE
conf.log : the port of "172.16.1.100:56364" is now fully colored

### DIFF
--- a/colourfiles/conf.log
+++ b/colourfiles/conf.log
@@ -52,8 +52,8 @@ regexp=([\w/\.\-]+)(\[\d+?\])
 colours=bold blue, bold red
 count=more
 ======
-# IPv4
-regexp=\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}
+# IPv4 or IPv4:Port
+regexp=\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(:\d{1,5})?
 colours=bold yellow
 count=more
 ======


### PR DESCRIPTION
With this log (from journalctl of openvpn, except the last line)
```
Dec 12 12:19:40 VPN ovpn-Serveur[355]: Initialization Sequence Completed
Dec 12 12:19:41 VPN ovpn-Serveur[355]: TCP connection established with [AF_INET]172.16.1.100:56364
Dec 12 12:19:41 VPN ovpn-Serveur[355]: 172.16.1.100:56364 TCP connection established with [AF_INET]88.77.66.22:54344
Dec 12 12:19:41 VPN ovpn-Serveur[355]: 172.16.1.100 TCP connection established with [AF_INET]88.77.66.22
```

Before, the last digit of port (4 of 56364, or 4 of 54344) was not colored

