### PR TITLE
Add completions for aliases when defined for zsh.

### DIFF
--- a/grc.zsh
+++ b/grc.zsh
@@ -1,4 +1,6 @@
-if [[ "$TERM" = dumb ]] || (( ! $+commands[grc] )); then
+#!/usr/bin/env zsh
+
+if [ "$TERM" = dumb ] || (( ! $+commands[grc] )); then
     return
 fi
 
@@ -77,13 +79,21 @@ cmds=(
   whois
 )
 
+function setup_alias() {
+  local name="$1"
+  local path="$(which "$name")"
+  $name() {
+    grc --colour=auto $commands[$0] "$@"
+  }
+  compdef "_${name}" "$name"
+}
+
 # Set alias for available commands.
 for cmd in $cmds ; do
   if (( $+commands[$cmd] )) ; then
-    alias $cmd="grc --colour=auto $commands[$cmd]"
+    setup_alias $cmd
   fi
 done
 
 # Clean up variables
-unset cmds cmd
-
+unset cmds cmd setup_alias

--- a/grc.zsh
+++ b/grc.zsh
@@ -12,6 +12,7 @@ cmds=(
   blkid
   cc
   configure
+  curl
   cvs
   df
   diff
@@ -74,6 +75,7 @@ cmds=(
   traceroute
   traceroute6
   tune2fs
+  ulimit
   uptime
   vmstat
   wdiff

--- a/grc.zsh
+++ b/grc.zsh
@@ -1,6 +1,7 @@
 #!/usr/bin/env zsh
 
-if [ "$TERM" = dumb ] || (( ! $+commands[grc] )); then
+if [ "$TERM" = dumb ] || (( ! $+commands[grc] ))
+then
     return
 fi
 


### PR DESCRIPTION
The current `grc.zsh` alias declarations overwrite the completions helper from zsh.

With wrapping the grc call as a function, the completion system still works.

More description available on github thread:
https://github.com/ohmyzsh/ohmyzsh/issues/6954