### PR TITLE
Improve Fish integration script

### DIFF
--- a/grc.fish
+++ b/grc.fish
@@ -1,12 +1,12 @@
 #!/usr/bin/env fish
 #
-# To load in ~/.config/fish/fish.conf or a new file in
+# To load in ~/.config/fish/config.fish or a new file in
 # ~/.config/fish/conf.d add:
-# source /etc/grc.fish (path may depend on install method)
+# source /etc/grc.fish (path may vary depending on installation method)
 #
 # See also the plugin at https://github.com/oh-my-fish/plugin-grc
 
-set -U grc_plugin_execs cat cvs df diff dig gcc g++ ls ifconfig \
+set -q grc_plugin_execs; or set -l grc_plugin_execs cat cvs df diff dig gcc g++ ls ifconfig \
        make mount mtr netstat ping ps tail traceroute \
        wdiff blkid du dnf docker docker-compose docker-machine env id ip iostat journalctl kubectl \
        last lsattr lsblk lspci lsmod lsof getfacl getsebool ulimit uptime nmap \
@@ -16,11 +16,7 @@ set -U grc_plugin_execs cat cvs df diff dig gcc g++ ls ifconfig \
 for executable in $grc_plugin_execs
     if type -q $executable
         function $executable --inherit-variable executable --wraps=$executable
-            if isatty 1
-                grc $executable $argv
-            else
-                eval command $executable $argv
-            end
+            grc $executable $argv
         end
     end
 end


### PR DESCRIPTION
- Fish config is located at `~/.config/fish/config.fish`, not `~/.config/fish/fish.conf`
- Allow overriding `$grc_plugin_execs`, also use correct variable scope (`-l` for local instead of `-U` for universal)
- Simplify wrapper function. As said in https://github.com/garabik/grc/pull/81#issuecomment-385191525, grc will handle non-terminal scenarios and thus the extra hassle in integration script is unnecessary.