### PR TITLE
Update nmap coloring to include variations

### DIFF
--- a/colourfiles/conf.nmap
+++ b/colourfiles/conf.nmap
@@ -1,5 +1,5 @@
 # Scan Title
-regexp=Nmap scan report for (\S+)\s\(([^\)]+)\)
+regexp=Nmap scan report for (\S+)(?:\s\(([^\)]+)\))?
 colours=default,bold green, bold magenta
 -
 # up
@@ -19,7 +19,7 @@ regexp=^PORT.*$|^HOP.*
 colours=bold
 -
 # Ports
-regexp=^(\d+)\/(\w+)\s+(\w+)\s+(\S+)
+regexp=^(\d+)\/(\w+)\s+([\w|]+)\s+(\S+)
 colours=default,bold green,magenta,cyan,bold yellow
 -
 # Ports Details


### PR DESCRIPTION
This PR will add coloring for the IP-address if you only scan an IP instead of a hostname.
It also allows the port combination `open|filtered`, which before was not considered.

Here are examples for the respective regexps:

* [Only IP scan](https://regex101.com/r/pdrH0a/1)
* [open|filtered Port](https://regex101.com/r/lBjieM/2)