### PR TITLE
Check for presence of TTY environment variable on zsh

### DIFF
--- a/grc.zsh
+++ b/grc.zsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env zsh
 
-if ! tty -s || [ ! -n "$TERM" ] || [ "$TERM" = dumb ] || (( ! $+commands[grc] ))
+if (! tty -s && [ -z "$TTY" ]) || [ ! -n "$TERM" ] || [ "$TERM" = dumb ] || (( ! $+commands[grc] ))
 then
   return
 fi


### PR DESCRIPTION
The instant-prompt feature of Powerlevel redirects stdin during zshrc causing grc not to load. This checks for the TTY environment variable in the event a tty isn't found.

See https://github.com/romkatv/powerlevel10k/issues/524 for background.