### PR TITLE
Fedora RPM changes

### DIFF
--- a/grc.spec
+++ b/grc.spec
@@ -1,20 +1,12 @@
-# Note that this is NOT a relocatable package
-%define ver      1.0.8
-%define rel      1
-%define prefix   /usr
-%define confdir  /etc
-
 Summary:   Generic Colouriser
 Name:      grc
-Version:   %ver
-Release:   %rel
-License: GPL
+Version:   1.13
+Release:   1
+License:   GPL
 Group:     Development/Tools
-Source:    grc-%{PACKAGE_VERSION}.tar.gz
-URL:       http://melkor.dnp.fmph.uniba.sk/~garabik/grc.html
-BuildRoot: %{_tmppath}/grc-%{PACKAGE_VERSION}-root
-Packager:  Valerij Klein <vklein@console-colors.de>
-BuildArchitectures: noarch
+URL:       http://kassiopeia.juls.savba.sk/~garabik/software/grc.html
+Source0:   https://github.com/garabik/grc/archive/v%{version}/%{name}-%{version}.tar.gz
+BuildArch: noarch
 
 %description
 Generic Colouriser is yet another colouriser for beautifying your logfiles
@@ -25,33 +17,28 @@ Authors:
     Radovan Garabik <garabik@melkor.dnp.fmph.uniba.sk>
 
 %prep
-%setup
+%autosetup -p1
+
+# Keep original timestamps
+sed -e 's/cp -fv /cp -fvp /' -i install.sh
 
 %install
-rm -rf $RPM_BUILD_ROOT
-
-install -d -m 755 $RPM_BUILD_ROOT%{prefix}/bin
-install -m 755 grc $RPM_BUILD_ROOT%{prefix}/bin
-install -m 755 grcat $RPM_BUILD_ROOT%{prefix}/bin
-install -d -m 755 $RPM_BUILD_ROOT%{prefix}/share/grc
-install -m 644 colorfiles/conf.* $RPM_BUILD_ROOT%{prefix}/share/grc
-install -d -m 755 $RPM_BUILD_ROOT%{confdir}
-install -m 644 grc.conf $RPM_BUILD_ROOT%{confdir}
-install -d -m 755 $RPM_BUILD_ROOT%{_mandir}/man1
-install -m 644 *.1 $RPM_BUILD_ROOT%{_mandir}/man1
-
-%clean
-rm -rf $RPM_BUILD_ROOT
+./install.sh "${RPM_BUILD_ROOT}%{_prefix}" "${RPM_BUILD_ROOT}"
 
 %files
-%defattr(-, root, root)
-
-%doc CHANGES CREDITS README TODO Regexp.txt
-%{prefix}/bin/*
-%{prefix}/share/grc/*
-%doc %{_mandir}/man1/*
-%config(noreplace) /etc/grc.conf
+%doc CHANGES CREDITS README* TODO Regexp.txt
+%license debian/copyright
+%{_bindir}/%{name}*
+%{_datadir}/%{name}/*
+%{_mandir}/man1/%{name}*
+%config(noreplace) %{_sysconfdir}/grc.conf
+%config(noreplace) %{_sysconfdir}/grc.zsh
+%config(noreplace) %{_sysconfdir}/grc.fish
+%config(noreplace) %{_sysconfdir}/profile.d/grc.sh
 
 %changelog
+* Mon Feb 07 2022 Petr Menšík <pemensik@redhat.com> - 1.13-1
+- Update spec file for Fedora guidelines
+
 * Fri Sep 01 2006 Valerij Klein <vklein@console-colors.de> 1.0.7-1
 - Minor changes in SPEC

--- a/install.sh
+++ b/install.sh
@@ -13,22 +13,22 @@ CONFDIR=$ETCPREFIX/etc
 PROFILEDIR=$CONFDIR/profile.d
 
 mkdir -p $BINDIR || true
-cp -fv grc grcat $BINDIR
+cp -fvp grc grcat $BINDIR
 mkdir -p $LIBDIR || true
-cp -fv colourfiles/conf.* $LIBDIR
+cp -fvp colourfiles/conf.* $LIBDIR
 mkdir -p $MANDIR/man1
-cp -fv grc.1 $MANDIR/man1
-cp -fv grcat.1 $MANDIR/man1
+cp -fvp grc.1 $MANDIR/man1
+cp -fvp grcat.1 $MANDIR/man1
 mkdir -p $CONFDIR
-cp -fv grc.conf $CONFDIR
-cp -fv grc.zsh $CONFDIR
-cp -fv grc.fish $CONFDIR
+cp -fvp grc.conf $CONFDIR
+cp -fvp grc.zsh $CONFDIR
+cp -fvp grc.fish $CONFDIR
 mkdir -p $PROFILEDIR
-cp -fv grc.sh $PROFILEDIR
+cp -fvp grc.sh $PROFILEDIR
 
 # probably we should not install it into site-functions in a debian package...
 if [ "$PREFIX" = "/usr/local" ]; then
   mkdir -p $PREFIX/zsh/site-functions
-  cp -fv _grc $PREFIX/zsh/site-functions
+  cp -fvp _grc $PREFIX/zsh/site-functions
 fi
 


### PR DESCRIPTION
Update RPM spec to be acceptable for inclusion of Fedora. I attempted to keep it reasonably compatible with any RPM based distribution, but I know only Fedora guidelines. Removes obsolete %clean section, the value is RPM default for ages.

Update latest version used, use rpm macros to set target directories. Use source code install.sh instead of duplicating it in spec file again. Make downloading source archive working with ``spectool -g *.spec``.

Update install.sh to keep original permissions and timestamp from source package. No installed file is modified.

I think this spec is ready for inclusion in Fedora