### PR TITLE
Support xterm-256 colors

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -152,6 +152,10 @@ Additional colours can be: `dark, italic, rapidblink, strikethrough`.
 These are supported only on some terminals, so if you want to write
 portable configuration files, avoid uing them (idea by James Rowe).
 
+xterm-256 colors are supported by using `xterm_<n>` or `on_xterm_<n>`. For example,
+to color light blue on a dark-grey background you can go
+`colours=xterm_81 on_xterm_237`
+
 there can be more attributes per line (separated by space), e.g.
 
     # this is probably a pathname

--- a/grcat
+++ b/grcat
@@ -91,6 +91,10 @@ colours = {
             'on_bright_white'   :    "\033[47;107m",
             }
 
+# add in xterm-256 colors
+for c in range(0, 256):
+    colours[f'xterm_{c}']    = f"\033[38;5;{c}m" # foreground
+    colours[f'on_xterm_{c}'] = f"\033[48;5;{c}m" # background
 
 # ignore ctrl C - this is not ideal for standalone grcat, but
 # enables propagating SIGINT to the other subprocess in grc


### PR DESCRIPTION
Hi this PR adds support for xterm-256colors 

You can access the full 256 colors of an xterm-256color terminal by
using xterm_<n> for foreground colors, or on_xterm_<n> for background.
For example, to color light blue on a dark-grey background you can use
colours=xterm_81 on_xterm_237