### PR TITLE
Support more locales in ls colorization

### DIFF
--- a/colourfiles/conf.ls
+++ b/colourfiles/conf.ls
@@ -35,8 +35,8 @@ regexp=\s(\d+),\s+(\d+)\s
 colours=default,bright_yellow ,yellow
 =======
 # Date-Time => G1=Month G2=Day G3=Hour G4=Minutes G5=Year
-regexp=([A-Z][a-z]{2})\s([ 1-3]\d)\s(?:([0-2]?\d):([0-5]\d)(?=[\s,]|$)|\s*(\d{4}))
-colours=unchanged,cyan,cyan,cyan,cyan,bold magenta
+regexp=(?:(\w{2,3})\s([ 1-3]\d)|([ 1-3]\d\.?)\s(\w{2,3}))\s(?:([0-2]?\d)[\.:]([0-5]\d)(?=[\s,]|$)|\s*(\d{4}))
+colours=unchanged,cyan,cyan,cyan,cyan,cyan,cyan,bold magenta
 =======
 # root
 regexp=\s(root|wheel)(?=\s|$)


### PR DESCRIPTION
Aternative to MR #176, which does not fix the issue properly even for mentioned German language.