### PR TITLE
Fix ls colors also for French

### DIFF
--- a/colourfiles/conf.ls
+++ b/colourfiles/conf.ls
@@ -35,7 +35,7 @@ regexp=\s(\d+),\s+(\d+)\s
 colours=default,bright_yellow ,yellow
 =======
 # Date-Time => G1=Month G2=Day G3=Hour G4=Minutes G5=Year
-regexp=(?:(\w{2,3})\s([ 1-3]\d)|([ 1-3]\d\.?)\s(\w{2,3}))\s(?:([0-2]?\d)[\.:]([0-5]\d)(?=[\s,]|$)|\s*(\d{4}))
+regexp=(?:(\w{2,5})\s([ 1-3]\d)|([ 1-3]\d\.?)\s(\w{2,5}\.?))\s{1,3}(?:([0-2]?\d)[\.:]([0-5]\d)(?=[\s,]|$)|(\d{4}))
 colours=unchanged,cyan,cyan,cyan,cyan,cyan,cyan,bold magenta
 =======
 # root


### PR DESCRIPTION
French locale has visible difference, which fails even after the last change.

Example:
fr_FR: 21 févr. 17:24

Allow up to 5 letters on month and accept also dot at the end of month
name. Do that only for one direction. Extend spaces matching after date.

Signed-off-by: Petr Menšík <pemensik@redhat.com>