### PR TITLE
Fix grc.fish argument handling bug

### DIFF
--- a/grc.fish
+++ b/grc.fish
@@ -19,7 +19,7 @@ for executable in $grc_plugin_execs
             if isatty 1
                 grc $executable $argv
             else
-                eval command $executable $argv
+                eval command $executable "$argv"
             end
         end
     end


### PR DESCRIPTION
This fixes a bug related to grc's handling of arguments when piping to another command in fish shell, the arguments should be quoted, but they weren't. This PR fixes that issue.

Demonstration of the previous issue, obviously this should cat a file named "file with spaces.txt" but it is instead treated as separate files:

```
❯ cat file\ with\ spaces.txt | cat
cat: file: No such file or directory
cat: with: No such file or directory
cat: spaces.txt: No such file or directory
```