### PR TITLE
Coloring improvements to iproute2 commands

### DIFF
--- a/colourfiles/conf.ip
+++ b/colourfiles/conf.ip
@@ -29,7 +29,7 @@ colours=on_blue
 -
 
 # ip range size
-regexp=/\d{1,2}
+regexp=/\d{1,3}\b
 colours=red
 -
 

--- a/colourfiles/conf.ipneighbor
+++ b/colourfiles/conf.ipneighbor
@@ -1,19 +1,27 @@
 # STATUS - STALE
-regexp=^(\S+)\s.*(STALE)$
+regexp=^(\S+)\s.*(STALE)\s*$
 colours=default,bright_red,bold red
 -
 # STATUS - FAILED
-regexp=^(\S+)\s.*(FAILED)$
+regexp=^(\S+)\s.*(FAILED)\s*$
 colours=default,bright_magenta,bold magenta
 -
 # Status - REACHABLE
-regexp=^(\S+)\s.*(REACHABLE)$
+regexp=^(\S+)\s.*(REACHABLE)\s*$
 colours=default,bright_green,green
 -
 # Status - DELAY
-regexp=^(\S+)\s.*(DELAY)$
+regexp=^(\S+)\s.*(DELAY)\s*$
 colours=default,bright_yellow,yellow
 -
 # DEV
-regexp=dev\s(\S+)
+regexp=\bdev\s(\S+)\b
 colours=default,cyan
+-
+# lladdr (other)
+regexp=\blladdr\s(\S+)\b
+colours=unchanged,blue
+-
+# lladdr (REACHABLE)
+regexp=\blladdr\s(\S+)\s.*(?<=REACHABLE)\s*$
+colours=unchanged,bold blue

--- a/colourfiles/conf.iproute
+++ b/colourfiles/conf.iproute
@@ -12,7 +12,11 @@ colours=green,bright_green,default,green
 =====
 # Network DEFAULT
 regexp=^default
-colours=on_green bold white
+colours=bold bright_green reverse
+=====
+# Network broadcast/multicast
+regexp=^(?:broadcast|multicast)
+colours=dark green
 =====
 # Local
 regexp=(src)\s(\S+)\s?

--- a/colourfiles/conf.iprule
+++ b/colourfiles/conf.iprule
@@ -1,0 +1,43 @@
+# priority
+regexp=^\d+:\s
+colours=green
+-
+# from/to all
+regexp=\b(from|to)\s(all)\b
+colours=default,default,italic yellow
+-
+# from/to ipv4
+regexp=\b(from|to)\s(\d+\.\d+\.\d+\.\d+)/?(\d+)?\b
+colours=default,default,yellow,magenta
+-
+# from/to ipv6
+regexp=\b(from|to)\s([0-9a-f:]+)/?(\d+)?\b
+colours=default,default,yellow,magenta
+-
+# fwmark
+regexp=\bfwmark\s(0x[0-9a-f]+)/(0x[0-9a-f]+)\b
+colours=default,bold red,red
+-
+# iif/oif
+regexp=\b[io]if\s(\S+)\b
+colours=default,bold cyan
+-
+# ipproto
+regexp=\bipproto\s(\S+)\b
+colours=default,blue
+-
+# sport/dport
+regexp=\b[sd]port\s(\d+)\b
+colours=default,bright_green
+-
+# lookup
+regexp=\blookup\s(\S+)\b
+colours=default,bold blue
+-
+# suppress_prefixlength
+regexp=\bsuppress_prefixlength\s(\d+)\b
+colours=default,bold yellow
+-
+# unreachable
+regexp=\bunreachable\b
+colours=reverse

--- a/grc.conf
+++ b/grc.conf
@@ -105,6 +105,10 @@ conf.iproute
 ^([/\w\.]+\/)?ip( -\w+)* n(e(i(g(h(b(o(ur?)?)?)?)?)?)?)?\b
 conf.ipneighbor
 
+# ip route
+^([/\w\.]+\/)?ip( -\w+)* r(u(le?)?)?\b
+conf.iprule
+
 # ip command - rest of commands
 ^([/\w\.]+\/)?ip\b
 conf.ip


### PR DESCRIPTION
This change includes some coloring improvements to `iproute2`-family commands.

**ip route**:
- improved contrast of "default" labels by using reverse video effect
- darken "broadcast" and "multicast" labels

After | Before:
![image](https://github.com/garabik/grc/assets/529520/5ab291e4-3748-4280-9f69-40dc0f1256be)

**ip neighbour**:
- fixed coloring of neighbour states (at least in iproute2 6.9.0 there is a space character at the end of each line)
- added coloring for mac addresses

After | Before:
![image](https://github.com/garabik/grc/assets/529520/61b3446a-6d70-4957-93ee-873a0507b92d)

**ip rule**:
- added coloring for `ip rule`

![image](https://github.com/garabik/grc/assets/529520/fd8766fe-3234-458c-80e1-c434ce14ca1a)
