### PR TITLE
work on whois regex

### DIFF
--- a/colourfiles/conf.whois
+++ b/colourfiles/conf.whois
@@ -1,5 +1,5 @@
 # field
-regexp=^([\w\s])*:
+regexp=^\s*([\w\s-])*:(?=\s|$)
 colours=bold white
 =======
 # data

--- a/colourfiles/conf.whois
+++ b/colourfiles/conf.whois
@@ -18,6 +18,14 @@ colours=yellow
 regexp=(([\w\d]([\w\d-])+\.){1,})([\w\d-]{2,})
 colours=green
 =======
+# IPv4
+regexp=\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}
+colours=green
+=======
+# IPv6
+regexp=[0-9a-fA-F]{0,4}(\:\:?[0-9a-fA-F]{0,4})+?
+colours=green
+=======
 # url
 regexp=http[s]?://(([\w\d]([\w\d-])+\.){1,})([\w\d-]{2,})(/[\w\d\S\s]*)*
 colours=bold green


### PR DESCRIPTION
to also work on fields with a - in it

for example the template for RIPE aut-num object. fields like mp-import, which aren't catched by something else like `regexp=(Registry )?[Aa]dmin([\w\s\S])*:`, just have default color

```
 aut-num:        [mandatory]  [single]     [primary/lookup key]
 as-name:        [mandatory]  [single]     [ ]
 descr:          [optional]   [multiple]   [ ]
 member-of:      [optional]   [multiple]   [inverse key]
 import-via:     [optional]   [multiple]   [ ]
 import:         [optional]   [multiple]   [ ]
 mp-import:      [optional]   [multiple]   [ ]
 export-via:     [optional]   [multiple]   [ ]
 export:         [optional]   [multiple]   [ ]
 mp-export:      [optional]   [multiple]   [ ]
 default:        [optional]   [multiple]   [ ]
 mp-default:     [optional]   [multiple]   [ ]
 remarks:        [optional]   [multiple]   [ ]
 org:            [optional]   [single]     [inverse key]
 sponsoring-org: [optional]   [single]     [inverse key]
 admin-c:        [mandatory]  [multiple]   [inverse key]
 tech-c:         [mandatory]  [multiple]   [inverse key]
 abuse-c:        [optional]   [single]     [inverse key]
 status:         [generated]  [single]     [ ]
 notify:         [optional]   [multiple]   [inverse key]
 mnt-by:         [mandatory]  [multiple]   [inverse key]
 created:        [generated]  [single]     [ ]
 last-modified:  [generated]  [single]     [ ]
 source:         [mandatory]  [single]     [ ]
```


also within for example this object type there might be lines after mp-import starting with \s<IPv6>, therefor added the check for end-of-line or \s

also added support for IPv4 and IPv6 copied from conf.ip